### PR TITLE
call inhibitReloadPopup() when reload is completed.

### DIFF
--- a/shell.qml
+++ b/shell.qml
@@ -13,5 +13,17 @@ import Quickshell
 import Quickshell.Hyprland
 
 ShellRoot {
+    Connections {
+        target: Quickshell
+
+        function onReloadCompleted() {
+            Quickshell.inhibitReloadPopup();
+        }
+
+        function onReloadFailed(error: string) {
+            Quickshell.inhibitReloadPopup();
+        }
+    }
+
     Overview {}
 }

--- a/shell.qml
+++ b/shell.qml
@@ -19,10 +19,6 @@ ShellRoot {
         function onReloadCompleted() {
             Quickshell.inhibitReloadPopup();
         }
-
-        function onReloadFailed(error: string) {
-            Quickshell.inhibitReloadPopup();
-        }
     }
 
     Overview {}


### PR DESCRIPTION
# Problem
When using the matugen template, changing your wallpaper makes it to send an annoying reload popup. This PR fixes it by inhibiting the reload popup when it is reloaded successfully.

Eg.
<img width="336" height="95" alt="image" src="https://github.com/user-attachments/assets/2e161da9-fa60-464b-99e8-1d8206cd711e" />
