### PR TITLE
fix: support interacting with overview on any monitor (#18)

### DIFF
--- a/modules/overview/Overview.qml
+++ b/modules/overview/Overview.qml
@@ -43,7 +43,8 @@ Scope {
                 property bool canBeActive: root.monitorIsFocused
                 active: false
                 onCleared: () => {
-                    if (!active)
+                    // Only the monitor that owns the grab may close the overview
+                    if (!active && canBeActive)
                         GlobalStates.overviewOpen = false;
                 }
             }
@@ -53,6 +54,21 @@ Scope {
                 function onOverviewOpenChanged() {
                     if (GlobalStates.overviewOpen) {
                         delayedGrabTimer.start();
+                    }
+                }
+            }
+
+            // Re-evaluate grab ownership when focused monitor changes
+            Connections {
+                target: Hyprland
+                function onFocusedMonitorChanged() {
+                    if (!GlobalStates.overviewOpen)
+                        return;
+                    // Transfer the grab to the newly focused monitor
+                    if (root.monitorIsFocused && !grab.active) {
+                        grab.active = true;
+                    } else if (!root.monitorIsFocused && grab.active) {
+                        grab.active = false;
                     }
                 }
             }


### PR DESCRIPTION
# Multi-monitor support for the overview

Closes Shanu-Kumawat/quickshell-overview#18.

## Disclosure

This work was done with Claude. The build has been running on my 2-monitor setup for ~2 weeks of daily use.

## What's fixed

`HyprlandFocusGrab` is guarded by `monitorIsFocused`, so only the monitor that was focused when the overview opened ever holds the grab. The moment focus moved to the other monitor, the grab cleared -> `onCleared` fired -> `GlobalStates.overviewOpen = false` -> overview closed.

The fix keeps the per-monitor guard but transfers grab ownership when `Hyprland.focusedMonitor` changes. At any instant exactly one monitor owns the grab, but it follows the focused monitor across monitors instead of staying pinned to the one the overview was opened on.

## Changes

Single commit, two changes in `Overview.qml`:

- Added a `Connections { target: Hyprland; function onFocusedMonitorChanged() }` block: while the overview is open, the new focused monitor activates *its* grab and the old focused monitor deactivates *its* grab. Ownership transfers cleanly between monitors as the user moves their mouse.
- Tightened `onCleared` to `if (!active && canBeActive)` so only the focused monitor's instance can close the overview. Clears coming from non-focused monitors are ignored — without this, the partial fix @ISTECTION tried (just removing the `canBeActive` guard entirely) makes every monitor's grab fire `active = true` simultaneously, the losers fire `onCleared`, and the overview closes immediately.

## Tested

- 2-monitor Hyprland setups: RTX 3080 + 1080p×2, and RTX 5070 + 1440p×2.
- Overview opens via `qs ipc -c overview call overview toggle`.
- Verified:
  - Opens on the focused monitor; can scroll/click/right-click on either monitor without closing.
  - Follows mouse focus when moving between monitors (grab transfers, doesn't conflict).
  - Closes via the documented paths: toggle bind, Escape/Enter, clicking a workspace tile, clicking a window preview, clicking a special workspace tile. Closing behaviour unchanged from upstream — the fix only suppresses the bug-path (close-on-monitor-switch).
- Daily use for ~2 weeks, no regressions noticed.

## Out of scope

While testing this I also noticed special workspaces (`special:sp1` etc.) only render on the monitor where they were toggled, because of `win.monitor !== root.monitor` filters in `OverviewWidget.qml`. Not sure if that is desired or not.
