### PR TITLE
feat: allow disabling program icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ Increase `topMargin` to move the overview down. Decrease it to move up.
 ```json
 {
   "windowPreview": {
+    "showIcons": true,
     "iconToWindowRatio": 0.25,
     "iconToWindowRatioCompact": 0.45,
     "xwaylandIndicatorToIconRatio": 0.35,
@@ -512,6 +513,7 @@ Low-memory preset:
     "topMargin": 100
   },
   "windowPreview": {
+    "showIcons": true,
     "iconToWindowRatio": 0.25,
     "iconToWindowRatioCompact": 0.45,
     "xwaylandIndicatorToIconRatio": 0.35,

--- a/common/Config.qml
+++ b/common/Config.qml
@@ -146,6 +146,7 @@ Singleton {
         }
 
         property QtObject windowPreview: QtObject {
+            property bool showIcons: root.readBool("windowPreview.showIcons", true)
             property real iconToWindowRatio: root.readReal("windowPreview.iconToWindowRatio", 0.25)
             property real iconToWindowRatioCompact: root.readReal("windowPreview.iconToWindowRatioCompact", 0.45)
             property real xwaylandIndicatorToIconRatio: root.readReal("windowPreview.xwaylandIndicatorToIconRatio", 0.35)

--- a/config.example.json
+++ b/config.example.json
@@ -82,6 +82,7 @@
     "topMargin": 100
   },
   "windowPreview": {
+    "showIcons": true,
     "iconToWindowRatio": 0.25,
     "iconToWindowRatioCompact": 0.45,
     "xwaylandIndicatorToIconRatio": 0.35,

--- a/modules/overview/OverviewWindow.qml
+++ b/modules/overview/OverviewWindow.qml
@@ -52,6 +52,7 @@ Item { // Window
     property bool hovered: false
     property bool pressed: false
 
+    property bool showIcons: Config.options.windowPreview.showIcons
     property var iconToWindowRatio: Config.options.windowPreview.iconToWindowRatio
     property var xwaylandIndicatorToIconRatio: Config.options.windowPreview.xwaylandIndicatorToIconRatio
     property var iconToWindowRatioCompact: Config.options.windowPreview.iconToWindowRatioCompact
@@ -169,6 +170,7 @@ Item { // Window
 
             Image {
                 id: windowIcon
+                visible: root.showIcons
                 property var iconSize: {
                     const renderedSize = Math.min(root.width, root.height);
                     return renderedSize * (root.compactMode ? root.iconToWindowRatioCompact : root.iconToWindowRatio) / (root.monitorData?.scale ?? 1);


### PR DESCRIPTION
Add a new option to the config JSON - `windowPreview.showIcons` - allowing fully disabling program icons in previews.

Before:
<img width="389" height="212" alt="Before" src="https://github.com/user-attachments/assets/cbadc359-a5ab-4433-bd9b-ce984e6026b5" />

After (with icons explicitly disabled through `"showIcons": false`):
<img width="389" height="212" alt="After" src="https://github.com/user-attachments/assets/a30bdb8f-fe0f-4b3f-b5a6-a19b662975b9" />

The existing option `windowPreview.iconToWindowRatio` set to 0 still prints (albeit a very tiny) icon; this change allows for disabling it fully.
