### PR TITLE
fix: change focused workspace indicator layer

### DIFF
--- a/modules/overview/OverviewWidget.qml
+++ b/modules/overview/OverviewWidget.qml
@@ -1089,7 +1089,7 @@ Item {
                 property int activeWorkspaceColIndex: root.getWorkspaceColumn(root.effectiveActiveWorkspaceId)
                 x: (root.workspaceImplicitWidth + workspaceSpacing) * activeWorkspaceColIndex
                 y: (root.workspaceImplicitHeight + workspaceSpacing) * activeWorkspaceRowIndex
-                z: root.windowZ
+                z: root.windowDraggingZ - 1
                 width: root.workspaceImplicitWidth
                 height: root.workspaceImplicitHeight
                 color: "transparent"


### PR DESCRIPTION
Set "z" coordinate for focused workspace indicator to be just below dragged window.
Previously the indicator was rendered below the preview for full-screen programs.

| Before | After |
|--------|--------|
| <img width="981" height="541" alt="Before" src="https://github.com/user-attachments/assets/95b040df-6c03-4b2c-b185-0cddc87c7545" /> | <img width="973" height="535" alt="After" src="https://github.com/user-attachments/assets/e0a7443d-5136-47c2-bcd1-f5421bbc4f7e" /> | 

A dragged window is still rendered above the indicator:
<img width="413" height="236" alt="Dragged" src="https://github.com/user-attachments/assets/a9bbbc55-5476-405d-bb32-9831896a409d" />