### PR TITLE
feat: improvements to cropping windows and rendering outlines

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,10 +262,13 @@ Increase `topMargin` to move the overview down. Decrease it to move up.
     "iconToWindowRatio": 0.25,
     "iconToWindowRatioCompact": 0.45,
     "xwaylandIndicatorToIconRatio": 0.35,
-    "inactiveMonitorOpacity": 0.4
+    "inactiveMonitorOpacity": 0.4,
+    "cropToFill": false
   }
 }
 ```
+
+- `cropToFill`: crop full-screen windows to fill the workspace preview when `true`; keep the full window in preview with possible horizontal/vertical "padding" bars when `false`
 
 ### Performance Tuning
 
@@ -517,7 +520,8 @@ Low-memory preset:
     "iconToWindowRatio": 0.25,
     "iconToWindowRatioCompact": 0.45,
     "xwaylandIndicatorToIconRatio": 0.35,
-    "inactiveMonitorOpacity": 0.4
+    "inactiveMonitorOpacity": 0.4,
+    "cropToFill": false
   },
   "hacks": {
     "arbitraryRaceConditionDelay": 150,

--- a/common/Config.qml
+++ b/common/Config.qml
@@ -151,6 +151,7 @@ Singleton {
             property real iconToWindowRatioCompact: root.readReal("windowPreview.iconToWindowRatioCompact", 0.45)
             property real xwaylandIndicatorToIconRatio: root.readReal("windowPreview.xwaylandIndicatorToIconRatio", 0.35)
             property real inactiveMonitorOpacity: root.readReal("windowPreview.inactiveMonitorOpacity", 0.4)
+            property bool cropToFill: root.readBool("windowPreview.cropToFill", false)
         }
 
         property QtObject hacks: QtObject {

--- a/config.example.json
+++ b/config.example.json
@@ -86,7 +86,8 @@
     "iconToWindowRatio": 0.25,
     "iconToWindowRatioCompact": 0.45,
     "xwaylandIndicatorToIconRatio": 0.35,
-    "inactiveMonitorOpacity": 0.4
+    "inactiveMonitorOpacity": 0.4,
+    "cropToFill": false
   },
   "hacks": {
     "arbitraryRaceConditionDelay": 150,

--- a/modules/overview/OverviewWidget.qml
+++ b/modules/overview/OverviewWidget.qml
@@ -1,4 +1,5 @@
 import QtQuick
+import QtQuick.Effects
 import QtQuick.Layouts
 import Quickshell
 import Quickshell.Wayland
@@ -459,6 +460,7 @@ Item {
                                 : "transparent"
 
                             Image {
+                                id: workspaceWallpaper
                                 visible: workspace.showWallpaper
                                 anchors.fill: parent
                                 source: root.wallpaperSource(root.emptyWorkspaceWallpaperPath)
@@ -467,6 +469,26 @@ Item {
                                 cache: true
                                 smooth: true
                                 mipmap: true
+                                layer.enabled: workspace.showWallpaper
+                                layer.smooth: true
+                                layer.effect: MultiEffect {
+                                    maskEnabled: true
+                                    maskSource: workspaceWallpaperMask
+                                    maskThresholdMin: 0.5
+                                    maskSpreadAtMin: 1.0
+                                }
+                            }
+
+                            Item {
+                                id: workspaceWallpaperMask
+                                anchors.fill: parent
+                                visible: false
+                                layer.enabled: true
+                                layer.smooth: true
+                                Rectangle {
+                                    anchors.fill: parent
+                                    radius: workspace.radius
+                                }
                             }
 
                             Rectangle {

--- a/modules/overview/OverviewWidget.qml
+++ b/modules/overview/OverviewWidget.qml
@@ -29,12 +29,12 @@ Item {
     property real scale: Config.options.overview.scale
     property color activeBorderColor: Appearance.colors.colSecondary
 
-    property real workspaceImplicitWidth: (monitorData?.transform % 2 === 1) ?
+    property real workspaceImplicitWidth: Math.round((monitorData?.transform % 2 === 1) ?
         ((monitor.height / monitor.scale - (monitorData?.reserved?.[0] ?? 0) - (monitorData?.reserved?.[2] ?? 0)) * root.scale) :
-        ((monitor.width / monitor.scale - (monitorData?.reserved?.[0] ?? 0) - (monitorData?.reserved?.[2] ?? 0)) * root.scale)
-    property real workspaceImplicitHeight: (monitorData?.transform % 2 === 1) ?
+        ((monitor.width / monitor.scale - (monitorData?.reserved?.[0] ?? 0) - (monitorData?.reserved?.[2] ?? 0)) * root.scale))
+    property real workspaceImplicitHeight: Math.round((monitorData?.transform % 2 === 1) ?
         ((monitor.width / monitor.scale - (monitorData?.reserved?.[1] ?? 0) - (monitorData?.reserved?.[3] ?? 0)) * root.scale) :
-        ((monitor.height / monitor.scale - (monitorData?.reserved?.[1] ?? 0) - (monitorData?.reserved?.[3] ?? 0)) * root.scale)
+        ((monitor.height / monitor.scale - (monitorData?.reserved?.[1] ?? 0) - (monitorData?.reserved?.[3] ?? 0)) * root.scale))
 
     property real workspaceNumberMargin: 80
     property real workspaceNumberSize: Config.options.overview.workspaceNumberBaseSize * monitor.scale

--- a/modules/overview/OverviewWindow.qml
+++ b/modules/overview/OverviewWindow.qml
@@ -1,5 +1,6 @@
 import QtQuick
 import QtQuick.Layouts
+import QtQuick.Effects
 import Quickshell
 import Quickshell.Wayland
 import "../../common"
@@ -56,6 +57,7 @@ Item { // Window
     property var iconToWindowRatio: Config.options.windowPreview.iconToWindowRatio
     property var xwaylandIndicatorToIconRatio: Config.options.windowPreview.xwaylandIndicatorToIconRatio
     property var iconToWindowRatioCompact: Config.options.windowPreview.iconToWindowRatioCompact
+    property bool cropToFill: Config.options.windowPreview.cropToFill
     property bool previewsEnabled: Config.options.overview.previewsEnabled
     property bool includeInactiveMonitorPreviews: Config.options.overview.includeInactiveMonitorPreviews
     property int previewRecaptureDelayMs: Config.options.overview.previewRecaptureDelayMs
@@ -121,45 +123,64 @@ Item { // Window
 
     ScreencopyView {
         id: windowPreview
-        anchors.fill: parent
+        readonly property real srcAspect: {
+            const w = root.windowData?.size?.[0] ?? 0;
+            const h = root.windowData?.size?.[1] ?? 0;
+            return (w > 0 && h > 0) ? (w / h) : 1;
+        }
+        anchors.centerIn: parent
+        width: root.cropToFill
+            ? Math.max(parent.width, parent.height * srcAspect)
+            : Math.min(parent.width, parent.height * srcAspect)
+        height: root.cropToFill
+            ? Math.max(parent.height, parent.width / srcAspect)
+            : Math.min(parent.height, parent.width / srcAspect)
         captureSource: shouldCapturePreview ? root.toplevel : null
         live: livePreviewEnabled
+        layer.enabled: true
+        layer.smooth: true
+        layer.effect: MultiEffect {
+            maskEnabled: true
+            maskSource: previewMask
+            maskThresholdMin: 0.5
+            maskSpreadAtMin: 1.0
+        }
+    }
+
+    Rectangle {
+        anchors.fill: parent
+        radius: Appearance.rounding.windowRounding * root.scale
+        color: pressed ? ColorUtils.applyAlpha(Appearance.colors.colLayer2Active, Math.min(1, root.effectiveWindowOverlayOpacity + 0.30)) :
+            hovered ? ColorUtils.applyAlpha(Appearance.colors.colLayer2Hover, Math.min(1, root.effectiveWindowOverlayOpacity + 0.20)) :
+            ColorUtils.applyAlpha(
+                root.glassMode ? ColorUtils.mix(Appearance.colors.colLayer2, Appearance.colors.colLayer0, 0.38) : Appearance.colors.colLayer2,
+                root.effectiveWindowOverlayOpacity
+            )
+        border.color: root.glassMode
+            ? ColorUtils.applyAlpha(Appearance.m3colors.m3outline, 0.62)
+            : ColorUtils.transparentize(Appearance.m3colors.m3outline, 0.7)
+        border.width: 1
 
         Rectangle {
+            visible: root.glassMode
             anchors.fill: parent
-            radius: Appearance.rounding.windowRounding * root.scale
-            color: pressed ? ColorUtils.applyAlpha(Appearance.colors.colLayer2Active, Math.min(1, root.effectiveWindowOverlayOpacity + 0.30)) :
-                hovered ? ColorUtils.applyAlpha(Appearance.colors.colLayer2Hover, Math.min(1, root.effectiveWindowOverlayOpacity + 0.20)) :
-                ColorUtils.applyAlpha(
-                    root.glassMode ? ColorUtils.mix(Appearance.colors.colLayer2, Appearance.colors.colLayer0, 0.38) : Appearance.colors.colLayer2,
-                    root.effectiveWindowOverlayOpacity
-                )
-            border.color : root.glassMode
-                ? ColorUtils.applyAlpha(Appearance.m3colors.m3outline, 0.62)
-                : ColorUtils.transparentize(Appearance.m3colors.m3outline, 0.7)
-            border.width : 1
-
-            Rectangle {
-                visible: root.glassMode
-                anchors.fill: parent
-                radius: parent.radius
-                color: "transparent"
-                gradient: Gradient {
-                    GradientStop { position: 0.0; color: ColorUtils.applyAlpha("#FFFFFF", root.glassShineOpacity * 0.24) }
-                    GradientStop { position: 0.5; color: ColorUtils.applyAlpha("#FFFFFF", 0.0) }
-                    GradientStop { position: 1.0; color: ColorUtils.applyAlpha("#000000", root.glassShineOpacity * 0.14) }
-                }
+            radius: parent.radius
+            color: "transparent"
+            gradient: Gradient {
+                GradientStop { position: 0.0; color: ColorUtils.applyAlpha("#FFFFFF", root.glassShineOpacity * 0.24) }
+                GradientStop { position: 0.5; color: ColorUtils.applyAlpha("#FFFFFF", 0.0) }
+                GradientStop { position: 1.0; color: ColorUtils.applyAlpha("#000000", root.glassShineOpacity * 0.14) }
             }
+        }
 
-            Rectangle {
-                visible: root.glassMode
-                anchors.fill: parent
-                anchors.margins: 1
-                radius: Math.max(parent.radius - 1, 0)
-                color: "transparent"
-                border.width: 1
-                border.color: ColorUtils.applyAlpha("#FFFFFF", root.glassShineOpacity * 0.32)
-            }
+        Rectangle {
+            visible: root.glassMode
+            anchors.fill: parent
+            anchors.margins: 1
+            radius: Math.max(parent.radius - 1, 0)
+            color: "transparent"
+            border.width: 1
+            border.color: ColorUtils.applyAlpha("#FFFFFF", root.glassShineOpacity * 0.32)
         }
 
         ColumnLayout {
@@ -181,6 +202,22 @@ Item { // Window
                 height: iconSize
                 sourceSize: Qt.size(Math.max(1, Math.round(iconSize)), Math.max(1, Math.round(iconSize)))
             }
+        }
+    }
+
+    Item {
+        id: previewMask
+        width: windowPreview.width
+        height: windowPreview.height
+        anchors.centerIn: parent
+        visible: false
+        layer.enabled: true
+        layer.smooth: true
+        Rectangle {
+            anchors.centerIn: parent
+            width: root.width
+            height: root.height
+            radius: Appearance.rounding.windowRounding * root.scale
         }
     }
 

--- a/modules/overview/OverviewWindow.qml
+++ b/modules/overview/OverviewWindow.qml
@@ -127,6 +127,18 @@ Item { // Window
         animation: Appearance.animation.elementMoveEnter.numberAnimation.createObject(this)
     }
 
+    // Opaque background for windows on the active monitor.
+    // The simplest solution for making those windows fully opaque and not interacting with actual
+    // windows behind the overview, e.g., applying blur to them.
+    Rectangle {
+        visible: (root.windowData?.monitor ?? -1) === root.widgetMonitorId
+        anchors.fill: parent
+        radius: Appearance.rounding.windowRounding * root.scale
+        color: root.glassMode
+            ? ColorUtils.mix(Appearance.colors.colLayer2, Appearance.colors.colLayer0, 0.38)
+            : Appearance.colors.colLayer2
+    }
+
     ScreencopyView {
         id: windowPreview
         readonly property real srcAspect: {

--- a/modules/overview/OverviewWindow.qml
+++ b/modules/overview/OverviewWindow.qml
@@ -100,6 +100,12 @@ Item { // Window
     width: Math.min(targetWindowWidth, availableWorkspaceWidth)
     height: Math.min(targetWindowHeight, availableWorkspaceHeight)
     opacity: (windowData?.monitor ?? -1) == widgetMonitorId ? 1 : Config.options.windowPreview.inactiveMonitorOpacity
+    visible: {
+        const thisWsId = windowData?.workspace?.id;
+        const isFullscreen = (windowData?.fullscreen ?? 0) > 0;
+        if (isFullscreen || thisWsId === undefined) return true;
+        return !HyprlandData.windowList.some(w => w.workspace?.id === thisWsId && (w.fullscreen ?? 0) > 0);
+    }
 
     clip: true
     Component.onCompleted: Qt.callLater(() => root.initialized = true)


### PR DESCRIPTION
Improve a couple of aspects regarding rendered outlines, masking, and full-screen windows.

## Fix issues with masking rounded corners on semi-transparent and blurred windows

| Before | After |
|--------|--------|
| <img width="973" height="532" alt="Before-corners" src="https://github.com/user-attachments/assets/1bbf730a-6b6c-4a85-8cfa-e048a73433c2" /> | <img width="973" height="532" alt="After-corners" src="https://github.com/user-attachments/assets/e26d6fa6-1070-49d9-babb-8fe093c5c997" /> |
| <img width="56" height="56" alt="Before-corner-zoomin" src="https://github.com/user-attachments/assets/3ee7855f-58b1-42eb-8e0d-6a69bd2e5d16" /> | <img width="56" height="56" alt="After-corner-zoomin" src="https://github.com/user-attachments/assets/7e037ece-4f40-4034-bcf0-7ff76897efc0" /> |

You can only really see it in the zoomed-in screenshot, but before not all of the window was masked to have a rounded corner.

## Fix rounding errors in workspace sizes

| Before | After |
|--------|--------|
| <img width="973" height="541" alt="Before-fullscreen" src="https://github.com/user-attachments/assets/fc7bf72a-f8bd-4d75-b54f-03dc9aed0679" /> | <img width="973" height="538" alt="After-fullscreen-nocrop" src="https://github.com/user-attachments/assets/5290309f-2d13-457b-aa7b-5c64e525b167" /> |
| <img width="212" height="36" alt="Before-fullscreen-zoomin" src="https://github.com/user-attachments/assets/f0e66b58-62d0-4274-ac42-5b97aaca246d" /> | <img width="215" height="39" alt="After-fullscreen-nocrop-zoomin" src="https://github.com/user-attachments/assets/014081f2-3f9e-4e1d-8a36-26d5454b4caa" /> |

On the zoomed-in screenshots you can see, than before the workspace preview background was sticking out slightly at the bottom.

## Allow configuring whether full-screen programs should be zoomed in, or not

(note: this might look weird without #30)

Allow configuring through `windowPreview.cropToFill` in `config.json` whether full-screen programs should be zoomed-in/cropped to fill the workspace preview window (the new behavior); or whether they should be rendered in full, with possible horizontal/vertical "padding" bars (the legacy behavior).

This option is set to `false` by default to not change existing behavior and needs to be explicitly enabled.

| Before | After (with zoom-crop explicitly enabled) |
|--------|--------|
| <img width="973" height="541" alt="Before-fullscreen" src="https://github.com/user-attachments/assets/6aa85483-d1c6-41a7-bc4d-b0f03640783e" /> | <img width="976" height="535" alt="After-fullscreen-crop" src="https://github.com/user-attachments/assets/0310843d-01e3-464d-84a8-1c0bc994d2c9" /> |
| <img width="60" height="60" alt="Before-fullscreen-corner-zoomin" src="https://github.com/user-attachments/assets/beb5601d-d466-4548-9890-88dc27b51c16" /> | <img width="60" height="60" alt="After-fullscreen-crop-corner-zoomin" src="https://github.com/user-attachments/assets/af4b34ba-055d-40b4-97a5-d034e05487b0" /> |

## Fix workspace wallpaper not getting rounded corners
| Before | After |
|--------|--------|
| <img width="337" height="330" alt="Before-wallpaper" src="https://github.com/user-attachments/assets/80f872c6-b153-4a79-b776-852e7df636e2" /> | <img width="243" height="235" alt="After-wallpaper" src="https://github.com/user-attachments/assets/68639205-94cb-4216-b960-f6879f372b92" /> |

## Fix visible windows "behind" full-screen programs on inactive monitors

| Before | After |
|--------|--------|
| <img width="981" height="541" alt="Before-fullscreen-inactive" src="https://github.com/user-attachments/assets/79cab772-a8aa-40e5-9b83-22b599dca636" /> | <img width="975" height="538" alt="After-fullscreen-inactive" src="https://github.com/user-attachments/assets/68462ea0-a0b3-4bd5-bd65-379565976f2b" /> |

## Fix window effects applied in preview windows

I noticed that for my terminal, which is semi-transparent and blurs the background, the preview window also applies the blur to a *actual* window which is behind it.

I fixed it kind of accidentally when trying to figure out how to restore windows being fully opaque on active monitor.

| Before | After |
|--------|--------|
| <img width="1407" height="529" alt="Before-blur" src="https://github.com/user-attachments/assets/ff341da1-1eaa-4641-ba76-c4d346859b84" /> | <img width="1404" height="529" alt="After-blur" src="https://github.com/user-attachments/assets/df6d7c45-4cfa-401c-825c-5ea906896712" /> |