### PR TITLE
fix: broken icons on first overview open after shell start

### DIFF
--- a/modules/overview/Overview.qml
+++ b/modules/overview/Overview.qml
@@ -222,7 +222,7 @@ Scope {
 
                 Loader {
                     id: overviewLoader
-                    active: GlobalStates.overviewOpen && (Config?.options.overview.enable ?? true)
+                    active: Config?.options.overview.enable ?? true
                     sourceComponent: OverviewWidget {
                         panelWindow: root
                         visible: true

--- a/modules/overview/OverviewWindow.qml
+++ b/modules/overview/OverviewWindow.qml
@@ -78,7 +78,10 @@ Item { // Window
             return true;
         return (windowData?.monitor ?? -1) === widgetMonitorId;
     }
-    property var entry: DesktopEntries.heuristicLookup(windowData?.class)
+    property var entry: {
+        DesktopEntries.applications.values; // re-run when the entry index updates
+        return DesktopEntries.heuristicLookup(windowData?.class);
+    }
     property string iconName: {
         const raw = `${entry?.icon ?? ""}`.trim();
         const withoutProviderPrefix = raw.replace(/^image:\/\/icon\//, "");


### PR DESCRIPTION
First time you open the overview after the shell starts, every window tile falls through to the missing-image placeholder instead of the app icon. Close it and reopen it and the icons show up correctly. Easy to reproduce with `systemctl --user restart quickshell-overview` followed by an immediate open.

The `entry` binding in `OverviewWindow.qml` calls `DesktopEntries.heuristicLookup(windowData?.class)`, and that binding only re-runs when its inputs change (i.e. when `windowData?.class` changes). During cold start the entry index isn't ready yet, so the lookup returns null, `iconName` falls back to `"application-x-executable"`, and `Quickshell.iconPath` returns the missing-image fallback. Once the index finishes loading nothing kicks the binding to retry, so the null sticks. Closing and reopening hides the bug because the `Loader` was rebuilding `OverviewWidget` from scratch each time, which forced a fresh lookup against the now-ready index.

Two changes:

- In `OverviewWindow.qml`, touch `DesktopEntries.applications.values` inside the `entry` binding so the QML engine subscribes to it. The lookup now retries the moment the index becomes available and `iconName` / `iconPath` settle to the right values.
- In `Overview.qml`, drop `GlobalStates.overviewOpen` from the `Loader.active` expression so the widget tree is built at shell startup. The icon / `DesktopEntries` lookups warm up before the first open instead of racing it. The `PanelWindow` and the parent `ColumnLayout` are still gated on `overviewOpen`, and `ScreencopyView` captures are still gated on `shouldCapturePreview`, so closed-state cost is unchanged — no extra capture traffic, no extra surfaces.

The first one is the actual fix. The second one prevents a single-frame flicker on the very first open that you'd otherwise still see while the index loads.

Tested by repeatedly restarting the service and opening the overview immediately — broken icons before, correct icons after. Open/close, drag-to-workspace, click-focus, middle-click-close, special workspaces and the `+` create tile all behave as before. Tried both `previewMode: "live"` and `previewMode: "event"`, no difference.

Closes #33
